### PR TITLE
Use Bootstrap's error feedback styles

### DIFF
--- a/src/View/Helper/BootsCakeFormHelper.php
+++ b/src/View/Helper/BootsCakeFormHelper.php
@@ -33,7 +33,7 @@ class BootsCakeFormHelper extends FormHelper
      */
     protected $_defaultConfig = [
         'idPrefix' => null,
-        'errorClass' => 'form-error',
+        'errorClass' => 'is-invalid',
         'typeMap' => [
             'string' => 'text',
             'text' => 'textarea',
@@ -62,7 +62,7 @@ class BootsCakeFormHelper extends FormHelper
             // Widget ordering for date/time/datetime pickers.
             'dateWidget' => '<div class="d-flex flex-row">{{day}}{{month}}{{year}}{{hour}}{{minute}}{{second}}{{meridian}}</div>',
             // Error message wrapper elements.
-            'error' => '<div class="error-message">{{content}}</div>',
+            'error' => '<div class="invalid-feedback mb-3">{{content}}</div>',
             // Container for error items.
             'errorList' => '<ul>{{content}}</ul>',
             // Error item wrapper.


### PR DESCRIPTION
Now invalid input and feeback message look like this:

![image](https://user-images.githubusercontent.com/12707758/72007857-622b1b80-3231-11ea-86bd-2cd628e9494d.png)
